### PR TITLE
feat: formLayout 을 동일한 역할 하는 prop으로 대체

### DIFF
--- a/src/components/auth/FindEmailFirstStep.tsx
+++ b/src/components/auth/FindEmailFirstStep.tsx
@@ -5,7 +5,6 @@ import { Button, Form, Input, message } from 'antd';
 import { FindEmailFirstStepRequest } from 'api/@types/auth';
 import { AuthService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
-import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { phoneNumberRegex } from 'utils/regex';
 
@@ -39,7 +38,7 @@ const FindEmailFirstStep: React.FC<Props> = ({ next }) => {
         validateTrigger={formValidateTrigger}
         onFinish={handleSubmit}
         onFinishFailed={onFormFinishFailed}
-        {...formLayout}
+        layout="vertical"
       >
         <Form.Item
           name="phoneNumber"

--- a/src/components/auth/FindEmailFirstStep.tsx
+++ b/src/components/auth/FindEmailFirstStep.tsx
@@ -5,6 +5,7 @@ import { Button, Form, Input, message } from 'antd';
 import { FindEmailFirstStepRequest } from 'api/@types/auth';
 import { AuthService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
+import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { phoneNumberRegex } from 'utils/regex';
 
@@ -38,6 +39,7 @@ const FindEmailFirstStep: React.FC<Props> = ({ next }) => {
         validateTrigger={formValidateTrigger}
         onFinish={handleSubmit}
         onFinishFailed={onFormFinishFailed}
+        {...formLayout}
       >
         <Form.Item
           name="phoneNumber"

--- a/src/components/auth/FindEmailSecondStep.tsx
+++ b/src/components/auth/FindEmailSecondStep.tsx
@@ -5,7 +5,6 @@ import { CountdownProps } from 'antd/es/statistic/Countdown';
 
 import { FindEmailFirstStepRequest, FindEmailSecondStepRequest } from 'api/@types/auth';
 import { AuthService } from 'api/services';
-import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 
 const { Countdown } = Statistic;
@@ -71,7 +70,7 @@ const FindEmailSecondStep: React.FC<Props> = ({ next, firstStepValues }) => {
     <>
       {contextHolder}
 
-      <Form<FormValues> form={form} onFinish={handleSubmit} {...formLayout}>
+      <Form<FormValues> form={form} onFinish={handleSubmit} layout="vertical">
         <Form.Item name="code" label="인증번호" rules={[requiredRule]} extra={codeExtraMessage}>
           <Input
             placeholder="인증번호를 입력하세요"

--- a/src/components/auth/FindEmailSecondStep.tsx
+++ b/src/components/auth/FindEmailSecondStep.tsx
@@ -5,6 +5,7 @@ import { CountdownProps } from 'antd/es/statistic/Countdown';
 
 import { FindEmailFirstStepRequest, FindEmailSecondStepRequest } from 'api/@types/auth';
 import { AuthService } from 'api/services';
+import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 
 const { Countdown } = Statistic;
@@ -70,7 +71,7 @@ const FindEmailSecondStep: React.FC<Props> = ({ next, firstStepValues }) => {
     <>
       {contextHolder}
 
-      <Form<FormValues> form={form} onFinish={handleSubmit}>
+      <Form<FormValues> form={form} onFinish={handleSubmit} {...formLayout}>
         <Form.Item name="code" label="인증번호" rules={[requiredRule]} extra={codeExtraMessage}>
           <Input
             placeholder="인증번호를 입력하세요"

--- a/src/components/auth/FindPasswordFirstStep.tsx
+++ b/src/components/auth/FindPasswordFirstStep.tsx
@@ -6,7 +6,6 @@ import { Button, Form, Input, message } from 'antd';
 import { FindPasswordFirstStepRequest } from 'api/@types/auth';
 import { AuthService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
-import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { phoneNumberRegex } from 'utils/regex';
 
@@ -40,7 +39,7 @@ const FindPasswordFirstStep: React.FC<Props> = ({ next }) => {
         validateTrigger={formValidateTrigger}
         onFinish={handleSubmit}
         onFinishFailed={onFormFinishFailed}
-        {...formLayout}
+        layout="vertical"
       >
         <Form.Item
           name="phoneNumber"

--- a/src/components/auth/FindPasswordFirstStep.tsx
+++ b/src/components/auth/FindPasswordFirstStep.tsx
@@ -6,6 +6,7 @@ import { Button, Form, Input, message } from 'antd';
 import { FindPasswordFirstStepRequest } from 'api/@types/auth';
 import { AuthService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
+import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { phoneNumberRegex } from 'utils/regex';
 
@@ -39,6 +40,7 @@ const FindPasswordFirstStep: React.FC<Props> = ({ next }) => {
         validateTrigger={formValidateTrigger}
         onFinish={handleSubmit}
         onFinishFailed={onFormFinishFailed}
+        {...formLayout}
       >
         <Form.Item
           name="phoneNumber"

--- a/src/components/auth/FindPasswordSecondStep.tsx
+++ b/src/components/auth/FindPasswordSecondStep.tsx
@@ -5,6 +5,7 @@ import { CountdownProps } from 'antd/es/statistic/Countdown';
 
 import { FindPasswordFirstStepRequest, FindPasswordSecondStepRequest } from 'api/@types/auth';
 import { AuthService } from 'api/services';
+import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 
 const { Countdown } = Statistic;
@@ -70,7 +71,7 @@ const FindPasswordSecondStep: React.FC<Props> = ({ next, firstStepValues }) => {
     <>
       {contextHolder}
 
-      <Form<FormValues> form={form} onFinish={handleSubmit}>
+      <Form<FormValues> form={form} onFinish={handleSubmit} {...formLayout}>
         <Form.Item name="code" label="인증번호" rules={[requiredRule]} extra={codeExtraMessage}>
           <Input
             placeholder="인증번호를 입력하세요"

--- a/src/components/auth/FindPasswordSecondStep.tsx
+++ b/src/components/auth/FindPasswordSecondStep.tsx
@@ -5,7 +5,6 @@ import { CountdownProps } from 'antd/es/statistic/Countdown';
 
 import { FindPasswordFirstStepRequest, FindPasswordSecondStepRequest } from 'api/@types/auth';
 import { AuthService } from 'api/services';
-import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 
 const { Countdown } = Statistic;
@@ -71,7 +70,7 @@ const FindPasswordSecondStep: React.FC<Props> = ({ next, firstStepValues }) => {
     <>
       {contextHolder}
 
-      <Form<FormValues> form={form} onFinish={handleSubmit} {...formLayout}>
+      <Form<FormValues> form={form} onFinish={handleSubmit} layout="vertical">
         <Form.Item name="code" label="인증번호" rules={[requiredRule]} extra={codeExtraMessage}>
           <Input
             placeholder="인증번호를 입력하세요"

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -10,6 +10,7 @@ import { LoginRequest } from 'api/@types/auth';
 import { AuthService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
 import atomStore from 'stores/atom';
+import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { token } from 'utils/token';
 
@@ -58,6 +59,7 @@ const SignInForm: React.FC = () => {
         validateTrigger={formValidateTrigger}
         onFinishFailed={onFormFinishFailed}
         scrollToFirstError
+        {...formLayout}
       >
         <Form.Item name="email" rules={[requiredRule]} hasFeedback={hasFeedback}>
           <Input prefix={<UserOutlined />} placeholder="이메일" allowClear />

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -10,7 +10,6 @@ import { LoginRequest } from 'api/@types/auth';
 import { AuthService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
 import atomStore from 'stores/atom';
-import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { token } from 'utils/token';
 
@@ -59,7 +58,7 @@ const SignInForm: React.FC = () => {
         validateTrigger={formValidateTrigger}
         onFinishFailed={onFormFinishFailed}
         scrollToFirstError
-        {...formLayout}
+        layout="vertical"
       >
         <Form.Item name="email" rules={[requiredRule]} hasFeedback={hasFeedback}>
           <Input prefix={<UserOutlined />} placeholder="이메일" allowClear />

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -8,7 +8,6 @@ import { CreateUserRequest } from 'api/@types/auth';
 import { AuthService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
 import atomStore from 'stores/atom';
-import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { passwordRegex, phoneNumberRegex, realnameRegex, usernameRegex } from 'utils/regex';
 import { token } from 'utils/token';
@@ -60,7 +59,7 @@ const SignUpForm: React.FC = () => {
         onFinish={createUser}
         onFinishFailed={onFormFinishFailed}
         scrollToFirstError
-        {...formLayout}
+        layout="vertical"
       >
         <Form.Item
           name="email"

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -8,6 +8,7 @@ import { CreateUserRequest } from 'api/@types/auth';
 import { AuthService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
 import atomStore from 'stores/atom';
+import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { passwordRegex, phoneNumberRegex, realnameRegex, usernameRegex } from 'utils/regex';
 import { token } from 'utils/token';
@@ -15,11 +16,6 @@ import { token } from 'utils/token';
 interface FormValues extends CreateUserRequest {
   passwordConfirm?: string;
 }
-
-const layout = {
-  labelCol: { span: 24 },
-  wrapperCol: { span: 24 },
-};
 
 const SignUpForm: React.FC = () => {
   const router = useRouter();
@@ -64,7 +60,7 @@ const SignUpForm: React.FC = () => {
         onFinish={createUser}
         onFinishFailed={onFormFinishFailed}
         scrollToFirstError
-        {...layout}
+        {...formLayout}
       >
         <Form.Item
           name="email"

--- a/src/components/userPanel/PasswordConfigForm.tsx
+++ b/src/components/userPanel/PasswordConfigForm.tsx
@@ -5,15 +5,11 @@ import { Button, Form, Input, message } from 'antd';
 import { UpdateMyPasswordRequest } from 'api/@types/user';
 import { UserService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
+import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { passwordRegex } from 'utils/regex';
 
 interface FormValues extends UpdateMyPasswordRequest {}
-
-const layout = {
-  labelCol: { span: 24 },
-  wrapperCol: { span: 24 },
-};
 
 const PasswordConfigForm: React.FC = () => {
   const { formValidateTrigger, onFormFinishFailed, hasFeedback } = useFormValidateTrigger();
@@ -46,7 +42,7 @@ const PasswordConfigForm: React.FC = () => {
         validateTrigger={formValidateTrigger}
         onFinishFailed={onFormFinishFailed}
         scrollToFirstError
-        {...layout}
+        {...formLayout}
       >
         <Form.Item name="prevPassword" label="기존 비밀번호" rules={[requiredRule]} hasFeedback={hasFeedback}>
           <Input.Password />

--- a/src/components/userPanel/PasswordConfigForm.tsx
+++ b/src/components/userPanel/PasswordConfigForm.tsx
@@ -5,7 +5,6 @@ import { Button, Form, Input, message } from 'antd';
 import { UpdateMyPasswordRequest } from 'api/@types/user';
 import { UserService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
-import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { passwordRegex } from 'utils/regex';
 
@@ -42,7 +41,7 @@ const PasswordConfigForm: React.FC = () => {
         validateTrigger={formValidateTrigger}
         onFinishFailed={onFormFinishFailed}
         scrollToFirstError
-        {...formLayout}
+        layout="vertical"
       >
         <Form.Item name="prevPassword" label="기존 비밀번호" rules={[requiredRule]} hasFeedback={hasFeedback}>
           <Input.Password />

--- a/src/components/userPanel/UserConfigForm.tsx
+++ b/src/components/userPanel/UserConfigForm.tsx
@@ -7,7 +7,6 @@ import { UpdateMeRequest, UserDetail } from 'api/@types/user';
 import { UserService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
 import atomStore from 'stores/atom';
-import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { phoneNumberRegex, realnameRegex, usernameRegex } from 'utils/regex';
 
@@ -52,7 +51,7 @@ const UserConfigForm: React.FC = () => {
             username: me?.userInfo.username,
             realname: me?.userInfo.realname,
           }}
-          {...formLayout}
+          layout="vertical"
         >
           <Form.Item
             name="email"

--- a/src/components/userPanel/UserConfigForm.tsx
+++ b/src/components/userPanel/UserConfigForm.tsx
@@ -7,15 +7,11 @@ import { UpdateMeRequest, UserDetail } from 'api/@types/user';
 import { UserService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
 import atomStore from 'stores/atom';
+import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { phoneNumberRegex, realnameRegex, usernameRegex } from 'utils/regex';
 
 interface FormValues extends UpdateMeRequest {}
-
-const layout = {
-  labelCol: { span: 24 },
-  wrapperCol: { span: 24 },
-};
 
 const UserConfigForm: React.FC = () => {
   const [me, setMe] = useRecoilState(atomStore.meAtom);
@@ -56,7 +52,7 @@ const UserConfigForm: React.FC = () => {
             username: me?.userInfo.username,
             realname: me?.userInfo.realname,
           }}
-          {...layout}
+          {...formLayout}
         >
           <Form.Item
             name="email"

--- a/src/components/userPanel/UserDeleteForm.tsx
+++ b/src/components/userPanel/UserDeleteForm.tsx
@@ -8,15 +8,11 @@ import { DeleteMeRequest } from 'api/@types/user';
 import { UserService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
 import atomStore from 'stores/atom';
+import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { passwordRegex } from 'utils/regex';
 
 interface FormValues extends DeleteMeRequest {}
-
-const layout = {
-  labelCol: { span: 24 },
-  wrapperCol: { span: 24 },
-};
 
 const UserDeleteForm: React.FC = () => {
   const router = useRouter();
@@ -49,7 +45,7 @@ const UserDeleteForm: React.FC = () => {
         validateTrigger={formValidateTrigger}
         onFinishFailed={onFormFinishFailed}
         form={form}
-        {...layout}
+        {...formLayout}
       >
         <Form.Item
           label={

--- a/src/components/userPanel/UserDeleteForm.tsx
+++ b/src/components/userPanel/UserDeleteForm.tsx
@@ -8,7 +8,6 @@ import { DeleteMeRequest } from 'api/@types/user';
 import { UserService } from 'api/services';
 import { useFormValidateTrigger } from 'hooks/useFormValidateTrigger';
 import atomStore from 'stores/atom';
-import { formLayout } from 'utils/formLayout';
 import { requiredRule } from 'utils/formRules';
 import { passwordRegex } from 'utils/regex';
 
@@ -45,7 +44,7 @@ const UserDeleteForm: React.FC = () => {
         validateTrigger={formValidateTrigger}
         onFinishFailed={onFormFinishFailed}
         form={form}
-        {...formLayout}
+        layout="vertical"
       >
         <Form.Item
           label={

--- a/src/utils/formLayout.ts
+++ b/src/utils/formLayout.ts
@@ -1,0 +1,4 @@
+export const formLayout = {
+  labelCol: { span: 24 },
+  wrapperCol: { span: 24 },
+};

--- a/src/utils/formLayout.ts
+++ b/src/utils/formLayout.ts
@@ -1,4 +1,0 @@
-export const formLayout = {
-  labelCol: { span: 24 },
-  wrapperCol: { span: 24 },
-};


### PR DESCRIPTION
## Type
- [X] Feature
- [ ] Fix

## What & Why
<!-- What changes are being made? -->
<!-- Why are these changes necessary? -->
form layout prop 대체 및 미적용부에 적용

## AS-IS
<img width="561" alt="스크린샷 2023-01-24 오전 2 34 34" src="https://user-images.githubusercontent.com/57123802/214109637-f5b0fa84-3cf0-42eb-8b6e-b90070db94f1.png">

## TO-BE
<img width="559" alt="image" src="https://user-images.githubusercontent.com/57123802/214109524-b5fe3f06-1901-4eed-8b46-9718c112917c.png">

## Checklist
- [ ] If there is a related ticket(Jira), did you insert the ticket(Jira)?
