### PR TITLE
feat: nullable 객체 Optional Chaning 마감 처리

### DIFF
--- a/src/api/@types/posts.ts
+++ b/src/api/@types/posts.ts
@@ -8,9 +8,9 @@ export interface Post {
   userInfo: User;
   textContent: string;
   comments: CommentInfo[];
-  hashtags: string[];
+  hashtags: string[] | null;
   likeCount: number;
-  files: FileInfo[];
+  files: FileInfo[] | null;
   createdDate: string;
   updatedDate: string;
   likeUp: boolean;

--- a/src/components/post/postCard/PostCard.tsx
+++ b/src/components/post/postCard/PostCard.tsx
@@ -32,7 +32,7 @@ const PostCard: React.FC<Props> = ({ post }) => {
   }, [createdDate, updatedDate]);
 
   const imageUrls = useMemo(() => {
-    return files.map((image) => image.downloadUrl);
+    return files?.map((image) => image.downloadUrl);
   }, [files]);
 
   const handleUserProfileClicked = useCallback(() => {
@@ -84,13 +84,13 @@ const PostCard: React.FC<Props> = ({ post }) => {
           </section>
           <section className="mt-2">
             <span>{textContent}</span>
-            {hashtags.map((tag) => (
+            {hashtags?.map((tag) => (
               <Hashtag key={'postCardHashtag-' + tag} tag={tag} />
             ))}
           </section>
         </section>
 
-        {imageUrls.length !== 0 && (
+        {imageUrls?.length !== 0 && (
           <section className="mt-3">
             <PostCardCarousel imageUrls={imageUrls} />
           </section>

--- a/src/components/post/postCard/PostCard.tsx
+++ b/src/components/post/postCard/PostCard.tsx
@@ -90,7 +90,7 @@ const PostCard: React.FC<Props> = ({ post }) => {
           </section>
         </section>
 
-        {imageUrls && imageUrls.length !== 0 && (
+        {imageUrls && (
           <section className="mt-3">
             <PostCardCarousel imageUrls={imageUrls} />
           </section>

--- a/src/components/post/postCard/PostCard.tsx
+++ b/src/components/post/postCard/PostCard.tsx
@@ -90,7 +90,7 @@ const PostCard: React.FC<Props> = ({ post }) => {
           </section>
         </section>
 
-        {imageUrls?.length !== 0 && (
+        {imageUrls && imageUrls.length !== 0 && (
           <section className="mt-3">
             <PostCardCarousel imageUrls={imageUrls} />
           </section>


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

## What & Why
브라우저에서 nullable 한 객체로 인한 오류를 방지하였습니다.
iamgeUrl는 빈 배열로 주는 것이 자연스러울 수도 있지만, nullable 처리가 용이한 언어 특성 상 hashtags 와 함께 nullable 하게 변경하고 UI에서 처리하게 끔 하였습니다.
( 그냥 잡생각: 게시글 작성 hashtags 요청 시 null 값으로 설정되어 있었으므로 응답 또한 null 로 유지하였음 )

<!-- What changes are being made? -->
<!-- Why are these changes necessary? -->

## Checklist
- [ ] If there is a related ticket(Jira), did you insert the ticket(Jira)?
